### PR TITLE
MEX-513 faucet contract updates and deployment setup script

### DIFF
--- a/on-chain/mettalex-faucet/contracts/USDTFaucetV1.sol
+++ b/on-chain/mettalex-faucet/contracts/USDTFaucetV1.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.5.0;
+
+import "./SafeMath.sol";
+import "./IUSDT.sol";
+
+contract USDTFaucetV1 {
+    using SafeMath for uint256;
+    uint256 public dailyLimit;
+    address public tokenAddress;
+    address public owner;
+    //mapping for amount withdrawn and timestamp of withdrawal
+    mapping(address => uint256) public amountWithdrawn;
+    mapping(address => uint256) public lastWithdrawnAt;
+
+    constructor(address _tokenAddress, uint256 _limit) public {
+        tokenAddress = _tokenAddress;
+        dailyLimit = _limit;
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    function updateTokenAddress(address _tokenAddress) external onlyOwner {
+        tokenAddress = _tokenAddress;
+    }
+
+    function updateOwner(address _owner) external onlyOwner {
+        owner = _owner;
+    }
+
+    function updateDailyLimit(uint256 _dailyLimit) external onlyOwner {
+        dailyLimit = _dailyLimit;
+    }
+
+    function request(address user, uint256 amount) external onlyOwner {
+        require(msg.sender == owner, "Only Owner!");
+        require(amount <= dailyLimit, "Amount exceeding limit");
+        if (now.sub(lastWithdrawnAt[user]) <= 86400) {
+            require(
+                amountWithdrawn[user].add(amount) <= dailyLimit,
+                "Daily Limit Exceeded"
+            );
+        } else {
+            amountWithdrawn[user] = 0;
+            lastWithdrawnAt[user] = now;
+        }
+        IUSDT(tokenAddress).mint(user, amount);
+        amountWithdrawn[user] = amountWithdrawn[user].add(amount);
+    }
+}

--- a/on-chain/mettalex-faucet/contracts/USDTFaucetV2.sol
+++ b/on-chain/mettalex-faucet/contracts/USDTFaucetV2.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.0;
 import "./SafeMath.sol";
 import "./IUSDT.sol";
 
-contract USDTFaucet {
+contract USDTFaucetV2 {
     using SafeMath for uint256;
     uint256 public dailyLimit;
     address public tokenAddress;
@@ -21,6 +21,24 @@ contract USDTFaucet {
     modifier onlyOwner() {
         require(owner == msg.sender, "Ownable: caller is not the owner");
         _;
+    }
+
+    function getAmountWithdrawn(address _user)
+        external
+        view
+        returns (uint256 amount)
+    {
+        if (amountWithdrawn[_user] == 0) return 0;
+        amount = amountWithdrawn[_user];
+    }
+
+    function getLastWithdrawnAt(address _user)
+        external
+        view
+        returns (uint256 time)
+    {
+        if (lastWithdrawnAt[_user] == 0) return 0;
+        time = lastWithdrawnAt[_user];
     }
 
     function updateTokenAddress(address _tokenAddress) external onlyOwner {

--- a/on-chain/scripts/faucet_deployments.py
+++ b/on-chain/scripts/faucet_deployments.py
@@ -1,0 +1,58 @@
+from mettalex_contract_setup import connect, create_contract, deploy_contract, set_token_whitelist, connect_contract
+from pathlib import Path
+import json
+import os
+import subprocess
+
+
+def get_contracts(w3, strategy_version=1):
+    usdt_faucet_build_file = Path(
+        __file__).parent / ".." / 'mettalex-faucet' / 'build' / 'contracts' / 'USDTFaucet.json'
+    eth_distributor_build_file = Path(
+        __file__).parent / ".." / 'mettalex-faucet' / 'build' / 'contracts' / 'EthDistributor.json'
+
+    coin_build_file = Path(__file__).parent / ".." / 'mettalex-vault' / \
+        'build' / 'contracts' / 'CoinToken.json'
+
+    contracts = {
+        'USDTFaucet': create_contract(w3, usdt_faucet_build_file),
+        'ETHDistributor': create_contract(w3, eth_distributor_build_file),
+        'Coin': create_contract(w3, coin_build_file)
+    }
+    return contracts
+
+
+def deploy(w3, contracts):
+    account = w3.eth.defaultAccount
+
+    if not os.path.isfile('args.json'):
+        print('No args file')
+        return
+
+    with open('args.json', 'r') as f:
+        args = json.load(f)
+
+    usdt_faucet = deploy_contract(
+        w3, contracts['USDTFaucet'], *args['USDTFaucet'])
+    eth_distributor = deploy_contract(
+        w3, contracts['ETHDistributor'], *args['ETHDistributor'])
+
+    contract_addresses = {
+        'USDTFaucet': usdt_faucet.address,
+        'ETHDistributor': eth_distributor.address
+    }
+    return contract_addresses
+
+
+# setup
+w3, admin = connect('bsc-testnet', 'admin')
+contracts = get_contracts(w3)
+deployed_contract_address = deploy(w3, contracts)
+
+print(deployed_contract_address)
+
+#coin address on bsc-testnet
+coin = connect_contract(
+    w3, contracts['Coin'], '0xa5Ebc90a713908872f137f7e468c2d887a8A2869')
+
+set_token_whitelist(w3, coin, deployed_contract_address["USDTFaucet"], True)


### PR DESCRIPTION
Updated USDT faucet contract to include getters for amountWithdrawn and lastWithdrawnAt mappings as they were reverting on calling from web3 with bsc testnet.
Also added a script for faucet setup which perform following:
- Deploy USDT faucet
- Deploy ETH distributor contract
- Whitelist USDT faucet to mint USDT on request